### PR TITLE
Test docker-compose w/ github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,5 +13,9 @@ jobs:
      - uses: cachix/install-nix-action@v22
        with:
          nix_path: nixpkgs=channel:nixos-unstable
+     - name: run oracle
+       run: docker-compose up -d
      - name: build
        run: nix-build
+     - name: example
+       run: ./result/bin/example


### PR DESCRIPTION
Runs `oracle` server in background during CI. Paves the way for testing in CI.