### PR TITLE
Support selects with WHERE clauses and updates using postgresql-simple-like interface

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -1,17 +1,18 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+
 module Main where
 
 import Data.Functor.Identity
+import Data.Proxy
 import Data.Text (Text)
 import Database.Oracle.Simple
 import GHC.Generics
-import Data.Proxy
 
 main :: IO ()
 main = do
@@ -26,32 +27,32 @@ main = do
   print =<< ping conn
   release conn
 
-  putStrLn ""
+-- inserting
+--
+-- let insertStmt = "insert into sample_table values (:1, :2, :3, :4)"
+-- rowsAffected <- executeMany
+-- conn
+-- insertStmt
+--   [ (SampleTable "d001" "Some text!" (Just 9.99) (Just 64))
+--   , (SampleTable "d002" "Some more text" Nothing (Just 10))
+--   , (SampleTable "d003" "Hello world" (Just 3.14) Nothing)
+--   , (SampleTable "d004" "Goodbye!" Nothing Nothing)
+--   ]
+-- putStrLn $ "Rows affected: " <> show rowsAffected
 
-  -- inserting
-  let insertStmt = "insert into sample_table values (:1, :2, :3, :4)"
-  rowsAffected <- executeMany
-   conn
-   insertStmt
-   [ (SampleTable "d001" "Some text!" (Just 9.99) (Just 64))
-   , (SampleTable "d002" "Some more text" Nothing (Just 10))
-   , (SampleTable "d003" "Hello world" (Just 3.14) Nothing)
-   , (SampleTable "d004" "Goodbye!" Nothing Nothing)
-   ]
-  putStrLn $ "Rows affected: " <> show rowsAffected
+-- querying with WHERE clause; using Identity as a 1-tuple
+--
+-- let selectWhereStmt = "select * from sample_table where sample_string=:1"
+-- rows <- query @SampleTable conn selectWhereStmt (Identity @String "d001")
+-- mapM_ print rows
 
-  -- querying with where clause
-  let selectWhereStmt = "select * from sample_table where sample_string=:1 and sample_integer=:2"
-  rows <- query @SampleTable conn selectWhereStmt ("d001" :: String, 64 :: Int)
-  mapM_ print rows
+-- updating
+--
+-- let updateStmt = "update sample_table st set st.sample_double=:1 where st.sample_string=:2"
+-- rowsAffected <- execute conn updateStmt (Just @Double 123.45, "d002" :: String)
+-- putStrLn $ "Rows affected: " <> show rowsAffected
 
-  -- updating
-  let updateStmt = "update sample_table st set st.sample_double=:1 where st.sample_string=:2"
-  rowsAffected <- execute conn updateStmt (Just @Double 123.45, "d002" :: String)
-  putStrLn $ "Rows affected: " <> show rowsAffected
-
-
-newtype RowCount = RowCount { getRowCount :: Double }
+newtype RowCount = RowCount {getRowCount :: Double}
   deriving stock (Show)
   deriving newtype (HasDPINativeType, FromField)
 
@@ -64,24 +65,24 @@ data ReturnedRow = ReturnedRow
   , nullValue :: Maybe Double
   }
   deriving stock (Show, Generic)
-  deriving anyclass FromRow
+  deriving anyclass (FromRow)
 
 -- CREATE TABLE sample_table (
 --   sample_string VARCHAR(20) PRIMARY KEY,
---	 sample_text VARCHAR(50) NOT NULL,
---	 sample_double NUMBER(10,5),
---	 sample_integer NUMBER(10,0)
---);
+-- 	 sample_text VARCHAR(50) NOT NULL,
+-- 	 sample_double NUMBER(10,5),
+-- 	 sample_integer NUMBER(10,0)
+-- );
 
-data SampleTable =
-  SampleTable
+data SampleTable = SampleTable
   { sampleString :: String
   , sampleText :: Text
   , sampleDouble :: Maybe Double
   , sampleInteger :: Maybe Int
-  } deriving stock (Show, Generic)
-    deriving anyclass ToRow
-    deriving anyclass FromRow
+  }
+  deriving stock (Show, Generic)
+  deriving anyclass (ToRow)
+  deriving anyclass (FromRow)
 
 -- instance ToRow SampleTable where
 --   toRow SampleTable{..} = do

--- a/oracle-simple.cabal
+++ b/oracle-simple.cabal
@@ -38,6 +38,8 @@ library
     , Database.Oracle.Simple.FromField
     , Database.Oracle.Simple.ToRow
     , Database.Oracle.Simple.ToField
+    , Database.Oracle.Simple.Query
+    , Database.Oracle.Simple.Execute
   build-depends:
     base < 5, derive-storable, text, mtl
   hs-source-dirs:

--- a/src/Database/Oracle/Simple.hs
+++ b/src/Database/Oracle/Simple.hs
@@ -1,9 +1,9 @@
 module Database.Oracle.Simple (module X) where
 
+import Database.Oracle.Simple.Execute as X
 import Database.Oracle.Simple.FromField as X
 import Database.Oracle.Simple.FromRow as X
 import Database.Oracle.Simple.Internal as X
+import Database.Oracle.Simple.Query as X
 import Database.Oracle.Simple.ToField as X
 import Database.Oracle.Simple.ToRow as X
-import Database.Oracle.Simple.Query as X
-import Database.Oracle.Simple.Execute as X

--- a/src/Database/Oracle/Simple.hs
+++ b/src/Database/Oracle/Simple.hs
@@ -5,3 +5,5 @@ import Database.Oracle.Simple.FromRow as X
 import Database.Oracle.Simple.Internal as X
 import Database.Oracle.Simple.ToField as X
 import Database.Oracle.Simple.ToRow as X
+import Database.Oracle.Simple.Query as X
+import Database.Oracle.Simple.Execute as X

--- a/src/Database/Oracle/Simple/Execute.hs
+++ b/src/Database/Oracle/Simple/Execute.hs
@@ -1,11 +1,19 @@
 {-# LANGUAGE BangPatterns #-}
+
 module Database.Oracle.Simple.Execute where
 
 import Control.Monad (foldM)
 import Control.Monad.State.Strict (evalStateT)
 import Data.Word (Word64)
-import Database.Oracle.Simple.ToRow (ToRow, RowWriter(runRowWriter), toRow)
-import Database.Oracle.Simple.Internal (Connection, prepareStmt, Column(Column), dpiExecute, DPIModeExec(DPI_MODE_EXEC_COMMIT_ON_SUCCESS), getRowCount)
+import Database.Oracle.Simple.Internal
+  ( Column (Column)
+  , Connection
+  , DPIModeExec (DPI_MODE_EXEC_COMMIT_ON_SUCCESS)
+  , dpiExecute
+  , getRowCount
+  , prepareStmt
+  )
+import Database.Oracle.Simple.ToRow (RowWriter (runRowWriter), ToRow, toRow)
 
 -- | Execute an INSERT, UPDATE, or other SQL query that is not expected to return results.
 -- Returns the number of rows affected.
@@ -33,9 +41,9 @@ executeMany coon sql [] = pure 0
 executeMany conn sql params = do
   stmt <- prepareStmt conn sql
   foldM (go stmt) 0 params
-    where
-      go stmt !totalRowsAffected param = do
-        _ <- evalStateT (runRowWriter (toRow param) stmt) (Column 0)
-        dpiExecute stmt DPI_MODE_EXEC_COMMIT_ON_SUCCESS
-        rowsAffected <- getRowCount stmt
-        pure (totalRowsAffected + rowsAffected)
+ where
+  go stmt !totalRowsAffected param = do
+    _ <- evalStateT (runRowWriter (toRow param) stmt) (Column 0)
+    dpiExecute stmt DPI_MODE_EXEC_COMMIT_ON_SUCCESS
+    rowsAffected <- getRowCount stmt
+    pure (totalRowsAffected + rowsAffected)

--- a/src/Database/Oracle/Simple/Execute.hs
+++ b/src/Database/Oracle/Simple/Execute.hs
@@ -37,7 +37,7 @@ execute_ conn sql = do
 -- Returns the number of rows affected. If the list of parameters is empty, the function will simply
 -- return 0 without issuing the query to the backend.
 executeMany :: (ToRow a) => Connection -> String -> [a] -> IO Word64
-executeMany coon sql [] = pure 0
+executeMany conn sql [] = pure 0
 executeMany conn sql params = do
   stmt <- prepareStmt conn sql
   foldM (go stmt) 0 params

--- a/src/Database/Oracle/Simple/Execute.hs
+++ b/src/Database/Oracle/Simple/Execute.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE BangPatterns #-}
+module Database.Oracle.Simple.Execute where
+
+import Control.Monad (foldM)
+import Control.Monad.State.Strict (evalStateT)
+import Data.Word (Word64)
+import Database.Oracle.Simple.ToRow (ToRow, RowWriter(runRowWriter), toRow)
+import Database.Oracle.Simple.Internal (DPIConn, prepareStmt, Column(Column), dpiExecute, DPIModeExec(DPI_MODE_EXEC_COMMIT_ON_SUCCESS), getRowCount)
+
+-- | Execute an INSERT, UPDATE, or other SQL query that is not expected to return results.
+-- Returns the number of rows affected.
+execute :: (ToRow a) => DPIConn -> String -> a -> IO Word64
+execute conn sql param = do
+  stmt <- prepareStmt conn sql
+  _ <- evalStateT (runRowWriter (toRow param) stmt) (Column 0)
+  dpiExecute stmt DPI_MODE_EXEC_COMMIT_ON_SUCCESS
+  rowsAffected <- getRowCount stmt
+  pure rowsAffected
+
+-- | A version of 'execute' that does not perform query substitution.
+execute_ :: DPIConn -> String -> IO Word64
+execute_ conn sql = do
+  stmt <- prepareStmt conn sql
+  dpiExecute stmt DPI_MODE_EXEC_COMMIT_ON_SUCCESS
+  rowsAffected <- getRowCount stmt
+  pure rowsAffected
+
+-- | Execute a multi-row INSERT, UPDATE or other SQL query that is not expected to return results.
+-- Returns the number of rows affected. If the list of parameters is empty, the function will simply
+-- return 0 without issuing the query to the backend.
+executeMany :: (ToRow a) => DPIConn -> String -> [a] -> IO Word64
+executeMany coon sql [] = pure 0
+executeMany conn sql params = do
+  stmt <- prepareStmt conn sql
+  foldM (go stmt) 0 params
+    where
+      go stmt !totalRowsAffected param = do
+        _ <- evalStateT (runRowWriter (toRow param) stmt) (Column 0)
+        dpiExecute stmt DPI_MODE_EXEC_COMMIT_ON_SUCCESS
+        rowsAffected <- getRowCount stmt
+        pure (totalRowsAffected + rowsAffected)

--- a/src/Database/Oracle/Simple/FromRow.hs
+++ b/src/Database/Oracle/Simple/FromRow.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE DerivingStrategies #-}
@@ -11,15 +10,16 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Database.Oracle.Simple.FromRow where
 
 import Control.Exception hiding (TypeError)
 import Control.Monad
 import Control.Monad.State.Strict
+import Data.Functor.Identity
 import Data.Proxy
 import Data.Word
-import Data.Functor.Identity
 import Database.Oracle.Simple.FromField
 import Database.Oracle.Simple.Internal
 import GHC.Generics
@@ -42,15 +42,30 @@ instance (FromField a, FromField b, FromField c, FromField d, FromField e) => Fr
 
 instance (FromField a, FromField b, FromField c, FromField d, FromField e, FromField f) => FromRow (a, b, c, d, e, f)
 
-instance (FromField a, FromField b, FromField c, FromField d, FromField e, FromField f, FromField g) => FromRow (a, b, c, d, e, f, g)
+instance
+  (FromField a, FromField b, FromField c, FromField d, FromField e, FromField f, FromField g)
+  => FromRow (a, b, c, d, e, f, g)
 
-instance (FromField a, FromField b, FromField c, FromField d, FromField e, FromField f, FromField g, FromField h)
+instance
+  (FromField a, FromField b, FromField c, FromField d, FromField e, FromField f, FromField g, FromField h)
   => FromRow (a, b, c, d, e, f, g, h)
 
-instance (FromField a, FromField b, FromField c, FromField d, FromField e, FromField f, FromField g, FromField h, FromField i)
+instance
+  (FromField a, FromField b, FromField c, FromField d, FromField e, FromField f, FromField g, FromField h, FromField i)
   => FromRow (a, b, c, d, e, f, g, h, i)
 
-instance (FromField a, FromField b, FromField c, FromField d, FromField e, FromField f, FromField g, FromField h, FromField i, FromField j)
+instance
+  ( FromField a
+  , FromField b
+  , FromField c
+  , FromField d
+  , FromField e
+  , FromField f
+  , FromField g
+  , FromField h
+  , FromField i
+  , FromField j
+  )
   => FromRow (a, b, c, d, e, f, g, h, i, j)
 
 class GFromRow f where

--- a/src/Database/Oracle/Simple/Internal.hs
+++ b/src/Database/Oracle/Simple/Internal.hs
@@ -213,16 +213,19 @@ foreign import ccall "dpiConn_close"
     -> IO Int
 
 close :: Connection -> IO Int
-close conn = fromIntegral <$>
-  dpiConn_close conn (toDpiModeConnClose DPI_MODE_CONN_CLOSE_DEFAULT)
-    nullPtr 0
+close conn =
+  fromIntegral
+    <$> dpiConn_close
+      conn
+      (toDpiModeConnClose DPI_MODE_CONN_CLOSE_DEFAULT)
+      nullPtr
+      0
 
 fromDPIModeConnClose :: CUInt -> Maybe DPIPurity
 fromDPIModeConnClose 0 = Just DPI_PURITY_DEFAULT
 fromDPIModeConnClose 1 = Just DPI_PURITY_NEW
 fromDPIModeConnClose 2 = Just DPI_PURITY_SELF
 fromDPIModeConnClose _ = Nothing
-
 
 fromDPIPurity :: CUInt -> Maybe DPIPurity
 fromDPIPurity 0 = Just DPI_PURITY_DEFAULT

--- a/src/Database/Oracle/Simple/Internal.hs
+++ b/src/Database/Oracle/Simple/Internal.hs
@@ -706,14 +706,14 @@ foreign import ccall "dpiStmt_execute"
 --         uint32_t *numQueryColumns);
 
 -- | Execute a statement.
-execute
+dpiExecute
   :: DPIStmt
   -- ^ Statement to be executed
   -> DPIModeExec
   -- ^ Execution mode
   -> IO CUInt
   -- ^ query columns
-execute stmt mode =
+dpiExecute stmt mode =
   alloca $ \rowsPtr -> do
     throwOracleError =<< dpiStmt_execute stmt (toDPIModeExec mode) rowsPtr
     peek rowsPtr

--- a/src/Database/Oracle/Simple/Internal.hs
+++ b/src/Database/Oracle/Simple/Internal.hs
@@ -97,6 +97,10 @@ connect params = do
     peek connPtr -- error "createConn: oh no" -- throwIO ConnectionException
     -- TODO: fetch errorInfo struct... somehow?
 
+-- | Brackets a computation between opening and closing a connection.
+withConnect :: ConnectionParams -> (Connection -> IO c) -> IO c
+withConnect params = bracket (connect params) (close >> release)
+
 -- DPI_EXPORT int dpiConn_create(const dpiContext *context, const char *userName,
 --         uint32_t userNameLength, const char *password, uint32_t passwordLength,
 --         const char *connectString, uint32_t connectStringLength,

--- a/src/Database/Oracle/Simple/Query.hs
+++ b/src/Database/Oracle/Simple/Query.hs
@@ -1,12 +1,19 @@
 module Database.Oracle.Simple.Query where
 
-import GHC.Generics (Generic)
 import Control.Monad.State.Strict (evalStateT)
-import Database.Oracle.Simple.ToField (ToField)
 import Database.Oracle.Simple.FromField (FromField)
-import Database.Oracle.Simple.ToRow (ToRow, RowWriter(..), toRow)
 import Database.Oracle.Simple.FromRow (FromRow, getRow)
-import Database.Oracle.Simple.Internal (Connection, prepareStmt, dpiExecute, DPIModeExec(..), fetch, Column(..))
+import Database.Oracle.Simple.Internal
+  ( Column (Column)
+  , Connection
+  , DPIModeExec (DPI_MODE_EXEC_DEFAULT)
+  , dpiExecute
+  , fetch
+  , prepareStmt
+  )
+import Database.Oracle.Simple.ToField (ToField)
+import Database.Oracle.Simple.ToRow (RowWriter (runRowWriter), ToRow, toRow)
+import GHC.Generics (Generic)
 
 -- | Perform a SELECT or other SQL query that is expected to return results.
 -- All results are retrieved and converted before this function ends.

--- a/src/Database/Oracle/Simple/Query.hs
+++ b/src/Database/Oracle/Simple/Query.hs
@@ -1,0 +1,39 @@
+module Database.Oracle.Simple.Query where
+
+import GHC.Generics (Generic)
+import Control.Monad.State.Strict (evalStateT)
+import Database.Oracle.Simple.ToField (ToField)
+import Database.Oracle.Simple.FromField (FromField)
+import Database.Oracle.Simple.ToRow (ToRow, RowWriter(..), toRow)
+import Database.Oracle.Simple.FromRow (FromRow, getRow)
+import Database.Oracle.Simple.Internal (DPIConn, prepareStmt, dpiExecute, DPIModeExec(..), fetch, Column(..))
+
+-- | Perform a SELECT or other SQL query that is expected to return results.
+-- All results are retrieved and converted before this function ends.
+query :: (FromRow a, ToRow b) => DPIConn -> String -> b -> IO [a]
+query conn sql param = do
+  stmt <- prepareStmt conn sql
+  _ <- evalStateT (runRowWriter (toRow param) stmt) (Column 0)
+  dpiExecute stmt DPI_MODE_EXEC_DEFAULT
+  found <- fetch stmt
+  loop stmt [] found
+ where
+  loop stmt xs n | n < 1 = pure xs
+  loop stmt xs _ = do
+    tsVal <- getRow stmt
+    found <- fetch stmt
+    loop stmt (xs ++ [tsVal]) found
+
+-- | A version of 'query' that does not perform query substitution.
+query_ :: FromRow a => DPIConn -> String -> IO [a]
+query_ conn sql = do
+  stmt <- prepareStmt conn sql
+  dpiExecute stmt DPI_MODE_EXEC_DEFAULT
+  found <- fetch stmt
+  loop stmt [] found
+ where
+  loop stmt xs n | n < 1 = pure xs
+  loop stmt xs _ = do
+    tsVal <- getRow stmt
+    found <- fetch stmt
+    loop stmt (xs ++ [tsVal]) found

--- a/src/Database/Oracle/Simple/ToRow.hs
+++ b/src/Database/Oracle/Simple/ToRow.hs
@@ -15,6 +15,7 @@ module Database.Oracle.Simple.ToRow where
 
 import           Control.Monad
 import           Control.Monad.State.Strict
+import           Data.Functor.Identity
 import qualified Data.List                       as L
 import           Data.Proxy
 import           Data.Traversable
@@ -46,6 +47,29 @@ class ToRow a where
   toRow :: a -> RowWriter ()
   default toRow :: (GToRow (Rep a), Generic a) => a -> RowWriter ()
   toRow = gToRow . from
+
+instance ToField a => ToRow (Identity a)
+
+instance (ToField a, ToField b) => ToRow (a, b)
+
+instance (ToField a, ToField b, ToField c) => ToRow (a, b, c)
+
+instance (ToField a, ToField b, ToField c, ToField d) => ToRow (a, b, c, d)
+
+instance (ToField a, ToField b, ToField c, ToField d, ToField e) => ToRow (a, b, c, d, e)
+
+instance (ToField a, ToField b, ToField c, ToField d, ToField e, ToField f) => ToRow (a, b, c, d, e, f)
+
+instance (ToField a, ToField b, ToField c, ToField d, ToField e, ToField f, ToField g) => ToRow (a, b, c, d, e, f, g)
+
+instance (ToField a, ToField b, ToField c, ToField d, ToField e, ToField f, ToField g, ToField h)
+  => ToRow (a, b, c, d, e, f, g, h)
+
+instance (ToField a, ToField b, ToField c, ToField d, ToField e, ToField f, ToField g, ToField h, ToField i)
+  => ToRow (a, b, c, d, e, f, g, h, i)
+
+instance (ToField a, ToField b, ToField c, ToField d, ToField e, ToField f, ToField g, ToField h, ToField i, ToField j)
+  => ToRow (a, b, c, d, e, f, g, h, i, j)
 
 class GToRow f where
   gToRow :: f a -> RowWriter ()
@@ -81,14 +105,3 @@ writeField field = RowWriter $ \stmt -> do
           AsNull -> 1
           _ -> 0
     bindValueByPos stmt col (dpiNativeType (Proxy @a)) (DPIData{..})
-
-insert :: (ToRow a) => DPIConn -> String -> [a] -> IO Word64
-insert conn sql rows = do
-  stmt <- prepareStmt conn sql
-  foldM (go stmt) 0 rows
-    where
-      go stmt !totalRowsAffected row = do
-        _ <- evalStateT (runRowWriter (toRow row) stmt) (Column 0)
-        execute stmt DPI_MODE_EXEC_COMMIT_ON_SUCCESS
-        rowsAffected <- getRowCount stmt
-        pure (totalRowsAffected + rowsAffected)


### PR DESCRIPTION
- Add `execute`, `executeMany` and `execute_` for UPDATEs and INSERTs
- Add `query_` and `query` for SELECTs and SELECTs with WHERE clauses
- Add `ToRow` and `FromRow` instances for up to 10-tuples and `Identity`
- Add `withConnect` to bracket computations between opening and closing connections

Sample usage:
```haskell
-- select with where clause
let selectWhereStmt = "select * from sample_table where sample_string=:1"
rows <- query @SampleTable conn selectWhereStmt (Identity @String "d001")
mapM_ print rows

-- updates
let updateStmt = "update sample_table st set st.sample_double=:1 where st.sample_string=:2"
rowsAffected <- execute conn updateStmt (Just @Double 123.45, "d002" :: String)
putStrLn $ "Rows affected: " <> show rowsAffected
```