### PR TITLE
Bump Oracle to 23.0

### DIFF
--- a/db/startup.sh
+++ b/db/startup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+sqlplus -s username/password@localhost/devdb <<EOF
+
+-- drop test tables if exist..
+
+-- create test tables...
+
+-- populate test tables...
+
+-- etc
+
+EOF

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,12 @@
 version: "3"
 services:
-  oracle-xe:
-    container_name: oracle-xe
-    image: gvenzl/oracle-xe:18.4.0
+  dev-db:
+    container_name: dev-db
+    image: gvenzl/oracle-free:23-slim-faststart
+    volumes:
+      - ./db:/container-entrypoint-startdb.d
     environment:
+      ORACLE_DATABASE: devdb
       ORACLE_PASSWORD: password
       APP_USER: username
       APP_USER_PASSWORD: password

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -17,7 +17,7 @@ main :: IO ()
 main = hspec spec
 
 params :: ConnectionParams
-params = ConnectionParams "username" "password" "localhost/XEPDB1"
+params = ConnectionParams "username" "password" "localhost/devdb"
 
 spec :: Spec
 spec = do


### PR DESCRIPTION
- Makes the native JSON type available to play with
- Use oracle free, the successor to XE
- Add a script that can be used to populate the database for tests, demos, etc