### PR TITLE
Free strings allocated on the heap

### DIFF
--- a/src/Database/Oracle/Simple/Internal.hs
+++ b/src/Database/Oracle/Simple/Internal.hs
@@ -81,22 +81,12 @@ connectDPI
 connectDPI params = do
   ctx <- readIORef globalContext
   alloca $ \connPtr -> do
-    (userCString, fromIntegral -> userLen) <- newCStringLen (user params)
-    (passCString, fromIntegral -> passLen) <- newCStringLen (pass params)
-    (connCString, fromIntegral -> connLen) <- newCStringLen (connString params)
-    throwOracleError
-      =<< dpiConn_create
-        ctx
-        userCString
-        userLen
-        passCString
-        passLen
-        connCString
-        connLen
-        nullPtr
-        nullPtr
-        connPtr
-    peek connPtr
+    withCStringLen (user params) $ \(userCString, fromIntegral -> userLen) ->
+      withCStringLen (pass params) $ \(passCString, fromIntegral -> passLen) ->
+        withCStringLen (connString params) $ \(connCString, fromIntegral -> connLen) -> do
+          throwOracleError
+            =<< dpiConn_create ctx userCString userLen passCString passLen connCString connLen nullPtr nullPtr connPtr
+          peek connPtr
 
 -- | The order that the finalizers are declared in is very important
 -- The close must be defined /last/ so it can run /first/
@@ -893,6 +883,13 @@ instance Storable WriteBuffer where
   poke ptr (AsBytes dpiBytesVal) = poke (castPtr ptr) dpiBytesVal
   poke ptr (AsTimestamp dpiTimeStampVal) = poke (castPtr ptr) dpiTimeStampVal
   poke ptr AsNull = poke (castPtr ptr) nullPtr
+
+-- | Free all pointers in the WriteBuffer.
+-- Call only after the contents of the buffer (specifically, any pointers) are no longer needed.
+freeWriteBuffer :: WriteBuffer -> IO ()
+freeWriteBuffer (AsString cString) = free cString
+freeWriteBuffer (AsBytes DPIBytes{..}) = free dpiBytesPtr >> free dpiBytesEncoding
+freeWriteBuffer _ = pure ()
 
 foreign import ccall "dpiData_getDouble"
   dpiData_getDouble :: Ptr (DPIData ReadBuffer) -> IO Double

--- a/src/Database/Oracle/Simple/ToRow.hs
+++ b/src/Database/Oracle/Simple/ToRow.hs
@@ -110,3 +110,4 @@ writeField field = RowWriter $ \stmt -> do
           AsNull -> 1
           _ -> 0
     bindValueByPos stmt col (dpiNativeType (Proxy @a)) (DPIData{..})
+    freeWriteBuffer dataValue -- no longer needed as dpiStmt_bindValueByPos creates a memory-managed dpiVar


### PR DESCRIPTION
- Use `withCString` instead of `newCString` wherever possible.
- Free strings allocated with `newCString`.