### PR TITLE
Add additional parameters for configuring pools

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -50,7 +50,7 @@ main :: IO ()
 main = withPool params $ hspec . spec
 
 params :: ConnectionParams
-params = ConnectionParams "username" "password" "localhost/devdb"
+params = ConnectionParams "username" "password" "localhost/devdb" Nothing
 
 spec :: Pool -> Spec
 spec pool = do


### PR DESCRIPTION
I'm in need of the ability to change the default Oracle configuration when creating pools (mainly the [maxSessions](https://odpi-c.readthedocs.io/en/latest/structs/dpiPoolCreateParams.html#c.dpiPoolCreateParams.maxSessions) parameter, but a few others as well).  I went ahead and added the ability to do so and like the API for it for the most part.  The main idea is that a user can pass `Nothing` if they desire to just use the default connection parameters (we'll pass in a null pointer as before in this case) or they can pass in some `AddtionalConnectionParams` (in this case we'll call [dpiContext_initPoolCreateParams](https://odpi-c.readthedocs.io/en/latest/functions/dpiContext.html#c.dpiContext_initPoolCreateParams) in order to intitialize a pointer with the default pool params and then update with the user parameters accordingly).

The only spot I'm a bit iffy on is the [accessTokenCallback](https://odpi-c.readthedocs.io/en/latest/structs/dpiPoolCreateParams.html#c.dpiPoolCreateParams.accessTokenCallback).  As it stands right now, I really don't see us having to configure this (I've left it out of the `AdditionalConnectionParams` type), but I think we at least need to make sure it's in and around the right Haskell type anyway.  I've given it the type of `FunPtr ()` which I think should work, but my FFI-foo isn't exactly at the level of master.