### PR TITLE
Stop Using Overlappable Instances for ToField

### DIFF
--- a/oracle-simple.cabal
+++ b/oracle-simple.cabal
@@ -8,7 +8,7 @@ license:             MIT
 license-file:        LICENSE
 author:              David Johnson
 maintainer:          djohnson.m@gmail.com, khandkararjun@gmail.com
-copyright:           H-E-B (c) 2021
+copyright:           H-E-B (c) 2024
 category:            Database
 build-type:          Simple
 extra-source-files:  CHANGELOG.md
@@ -40,14 +40,14 @@ library
     Database.Oracle.Simple
   other-modules:
       Database.Oracle.Simple.Internal
-    , Database.Oracle.Simple.FromRow
-    , Database.Oracle.Simple.FromField
-    , Database.Oracle.Simple.ToRow
-    , Database.Oracle.Simple.ToField
-    , Database.Oracle.Simple.Query
     , Database.Oracle.Simple.Execute
-    , Database.Oracle.Simple.Pool
+    , Database.Oracle.Simple.FromField
+    , Database.Oracle.Simple.FromRow
     , Database.Oracle.Simple.JSON
+    , Database.Oracle.Simple.Pool
+    , Database.Oracle.Simple.Query
+    , Database.Oracle.Simple.ToField
+    , Database.Oracle.Simple.ToRow
     , Database.Oracle.Simple.Transaction
   build-depends:
     base < 5, bytestring, derive-storable, text, mtl, time, QuickCheck, aeson, scientific, vector, uuid, random

--- a/src/Database/Oracle/Simple/Execute.hs
+++ b/src/Database/Oracle/Simple/Execute.hs
@@ -5,6 +5,7 @@ module Database.Oracle.Simple.Execute where
 import Control.Monad (foldM)
 import Control.Monad.State.Strict (evalStateT)
 import Data.Word (Word64)
+
 import Database.Oracle.Simple.Internal
   ( Column (Column)
   , Connection
@@ -22,16 +23,14 @@ execute conn sql param = do
   stmt <- prepareStmt conn sql
   _ <- evalStateT (runRowWriter (toRow param) stmt) (Column 0)
   dpiExecute stmt DPI_MODE_EXEC_DEFAULT
-  rowsAffected <- getRowCount stmt
-  pure rowsAffected
+  getRowCount stmt
 
 -- | A version of 'execute' that does not perform query substitution.
 execute_ :: Connection -> String -> IO Word64
 execute_ conn sql = do
   stmt <- prepareStmt conn sql
   dpiExecute stmt DPI_MODE_EXEC_DEFAULT
-  rowsAffected <- getRowCount stmt
-  pure rowsAffected
+  getRowCount stmt
 
 -- | Execute a multi-row INSERT, UPDATE or other SQL query that is not expected to return results.
 -- Returns the number of rows affected. If the list of parameters is empty, the function will simply

--- a/src/Database/Oracle/Simple/Query.hs
+++ b/src/Database/Oracle/Simple/Query.hs
@@ -1,6 +1,8 @@
 module Database.Oracle.Simple.Query where
 
 import Control.Monad.State.Strict (evalStateT)
+import GHC.Generics (Generic)
+
 import Database.Oracle.Simple.FromField (FromField)
 import Database.Oracle.Simple.FromRow (FromRow, getRow)
 import Database.Oracle.Simple.Internal
@@ -13,7 +15,6 @@ import Database.Oracle.Simple.Internal
   )
 import Database.Oracle.Simple.ToField (ToField)
 import Database.Oracle.Simple.ToRow (RowWriter (runRowWriter), ToRow, toRow)
-import GHC.Generics (Generic)
 
 -- | Perform a SELECT or other SQL query that is expected to return results.
 -- All results are retrieved and converted before this function ends.

--- a/src/Database/Oracle/Simple/ToField.hs
+++ b/src/Database/Oracle/Simple/ToField.hs
@@ -1,21 +1,20 @@
-{-# LANGUAGE NumericUnderscores #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Database.Oracle.Simple.ToField where
 
-import Data.Fixed
-import Data.Time
-import Data.Int
-import Data.Text
-import Numeric.Natural
-import Database.Oracle.Simple.Internal
 import qualified Data.Aeson as Aeson
-import Data.Proxy
+import Data.Int (Int, Int32, Int64)
+import Data.Proxy (Proxy(..))
+import Foreign.Marshal.Utils (fromBool)
+import qualified Data.Text as T
+import Data.Text (Text)
+import Data.Time (UTCTime(..), ZonedTime(..), LocalTime(..), TimeOfDay(..), TimeZone(..), toGregorian, utcToZonedTime, utc)
+import Numeric.Natural (Natural)
+
+import Database.Oracle.Simple.Internal
 
 class ToField a where
   toDPINativeType :: Proxy a -> DPINativeType
@@ -23,13 +22,17 @@ class ToField a where
   toField :: a -> IO WriteBuffer
   -- ^ Write a value of type @a@ to the data buffer.
 
+instance ToField Bool where
+  toDPINativeType _ = DPI_NATIVE_TYPE_BOOLEAN
+  toField = pure . AsBoolean . fromBool
+
 instance ToField Double where
   toDPINativeType _ = DPI_NATIVE_TYPE_DOUBLE
   toField = pure . AsDouble
 
 instance ToField Text where
   toDPINativeType _ = DPI_NATIVE_TYPE_BYTES
-  toField = fmap AsBytes . mkDPIBytesUTF8 . unpack
+  toField = fmap AsBytes . mkDPIBytesUTF8 . T.unpack
 
 instance ToField String where
   toDPINativeType _ = DPI_NATIVE_TYPE_BYTES


### PR DESCRIPTION
My opinion is that the JSON implementation comes with a large footgun since it can lead to `ToJSON`/`FromJSON` instances being used as the default `ToField`/`FromField` instances. Maybe this was desired but the overlappable instances also lead to confusing type errors.

This patch introduces `AesonField` for use with `DerivingVia`, so users can opt-in to using JSON serialization for their fields instead of inadvertently using aeson.

Other changes:

* Adds more explicit imports and removes redundant imports
* Amends generic `ToRow`/`FromRow` to eagerly trigger the sum type `TypeError`
* Removes a lot of redundant language extensions