### PR TITLE
Add Manual Storable Instances for DPIXid and VersionInfo (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ import GHC.Generics (Generic)
 main :: IO ()
 main = do
   let stmt = "select count(*), sysdate, 'ignore next column', 125.24, 3.14 from dual"
-  conn <- createConn (ConnectionParams "username" "password" "localhost/XEPDB1")
-  rows <- query @ReturnedRow conn stmt
+  conn <- connect (ConnectionParams "username" "password" "localhost/XEPDB1" Nothing)
+  rows <- query_ conn stmt :: IO [ReturnedRow]
   print rows
 
 -- [ ReturnedRow { count = RowCount {getRowCount = 1.0}

--- a/src/Database/Oracle/Simple/Internal.hs
+++ b/src/Database/Oracle/Simple/Internal.hs
@@ -33,6 +33,7 @@ module Database.Oracle.Simple.Internal
     ConnectionParams (..),
     OracleError (..),
     ErrorInfo (..),
+    VersionInfo (..),
     renderErrorInfo,
     ping,
     fetch,

--- a/src/Database/Oracle/Simple/Internal.hs
+++ b/src/Database/Oracle/Simple/Internal.hs
@@ -538,8 +538,28 @@ data VersionInfo = VersionInfo
   , portUpdateNum :: CInt
   , fullVersionNum :: CUInt
   }
-  deriving (Show, Eq, Generic)
-  deriving anyclass (GStorable)
+  deriving (Show, Eq)
+
+instance Storable VersionInfo where
+    sizeOf _ = sizeOf (undefined :: CInt) * 6
+    alignment _ = alignment (undefined :: CInt)
+    peek p = do
+        let basePtr = castPtr p
+        versionNum <- peekByteOff basePtr 0
+        releaseNum <- peekByteOff basePtr 4
+        updateNum <- peekByteOff basePtr 8
+        portReleaseNum <- peekByteOff basePtr 12
+        portUpdateNum <- peekByteOff basePtr 16
+        fullVersionNum <- peekByteOff basePtr 20
+        return VersionInfo{..}
+    poke p VersionInfo{..} = do
+        let basePtr = castPtr p
+        pokeByteOff basePtr 0 versionNum
+        pokeByteOff basePtr 4 releaseNum
+        pokeByteOff basePtr 8 updateNum
+        pokeByteOff basePtr 12 portReleaseNum
+        pokeByteOff basePtr 16 portUpdateNum
+        pokeByteOff basePtr 20 fullVersionNum
 
 getClientVersion ::
   IO VersionInfo

--- a/src/Database/Oracle/Simple/Transaction.hs
+++ b/src/Database/Oracle/Simple/Transaction.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -19,12 +17,11 @@ import Control.Exception (catch, throw)
 import Control.Monad (replicateM, void, when, (<=<))
 import Data.UUID (UUID, toString)
 import Data.UUID.V4 (nextRandom)
-import Foreign (alloca, peek, poke, withForeignPtr)
+import Foreign (alloca, withForeignPtr)
 import Foreign.C.String (CString, withCStringLen)
 import Foreign.C.Types (CInt (CInt), CLong, CUInt (CUInt))
-import Foreign.Ptr (Ptr)
-import Foreign.Storable.Generic (GStorable)
-import GHC.Generics (Generic)
+import Foreign.Ptr (Ptr ,castPtr)
+import Foreign.Storable (Storable(..))
 import System.Random (getStdRandom, uniformR)
 
 import Database.Oracle.Simple.Execute (execute_)
@@ -141,8 +138,86 @@ data DPIXid = DPIXid
   , dpixBranchQualifier :: CString
   , dpixBranchQualifierLength :: CUInt
   }
-  deriving (Generic, Show)
-  deriving anyclass (GStorable)
+  deriving (Show)
+
+instance Storable DPIXid where
+    sizeOf _ =
+        let
+            -- Sizes of fields
+            sizeFormatId = sizeOf (undefined :: CLong)
+            sizeTransactionId = sizeOf (undefined :: CString)
+            sizeTransactionIdLength = sizeOf (undefined :: CUInt)
+            sizeQualifier = sizeOf (undefined :: CString)
+            sizeQualifierLength = sizeOf (undefined :: CUInt)
+
+            -- Alignments of fields
+            alignFormatId = alignment (undefined :: CLong)
+            alignTransactionId = alignment (undefined :: CString)
+            alignTransactionIdLength = alignment (undefined :: CUInt)
+            alignQualifier = alignment (undefined :: CString)
+            alignQualifierLength = alignment (undefined :: CUInt)
+
+            -- Padding for each field
+            paddingTransactionId = padding sizeFormatId alignTransactionId
+            paddingTransactionIdLength = padding (sizeTransactionId + paddingTransactionId) alignTransactionIdLength
+            paddingQualifier = padding (sizeTransactionIdLength + paddingTransactionIdLength) alignQualifier
+            paddingQualifierLength = padding (sizeQualifier + paddingQualifier) alignQualifierLength
+        in
+            sizeFormatId +
+            paddingTransactionId + sizeTransactionId +
+            paddingTransactionIdLength + sizeTransactionIdLength +
+            paddingQualifier + sizeQualifier +
+            paddingQualifierLength + sizeQualifierLength +
+            -- Final padding to align the structure itself
+            padding (sizeFormatId +
+                     paddingTransactionId + sizeTransactionId +
+                     paddingTransactionIdLength + sizeTransactionIdLength +
+                     paddingQualifier + sizeQualifier +
+                     paddingQualifierLength + sizeQualifierLength) alignFormatId
+
+    alignment _ = alignment (undefined :: CLong)
+
+    peek p = do
+        let basePtr = castPtr p
+        formatId <- peekByteOff basePtr 0
+
+        let offsetTransactionId = alignedOffset 0 (sizeOf (undefined :: CLong)) (alignment (undefined :: CString))
+        transactionId <- peekByteOff basePtr offsetTransactionId
+
+        let offsetTransactionIdLength = offsetTransactionId + sizeOf (undefined :: CString)
+        transactionIdLength <- peekByteOff basePtr offsetTransactionIdLength
+
+        let offsetQualifier = alignedOffset offsetTransactionIdLength (sizeOf (undefined :: CUInt)) (alignment (undefined :: CString))
+        qualifier <- peekByteOff basePtr offsetQualifier
+
+        let offsetQualifierLength = offsetQualifier + sizeOf (undefined :: CString)
+        qualifierLength <- peekByteOff basePtr offsetQualifierLength
+
+        return $ DPIXid formatId transactionId transactionIdLength qualifier qualifierLength
+
+    poke p (DPIXid formatId transactionId transactionIdLength qualifier qualifierLength) = do
+        let basePtr = castPtr p
+        pokeByteOff basePtr 0 formatId
+
+        let offsetTransactionId = alignedOffset 0 (sizeOf (undefined :: CLong)) (alignment (undefined :: CString))
+        pokeByteOff basePtr offsetTransactionId transactionId
+
+        let offsetTransactionIdLength = offsetTransactionId + sizeOf (undefined :: CString)
+        pokeByteOff basePtr offsetTransactionIdLength transactionIdLength
+
+        let offsetQualifier = alignedOffset offsetTransactionIdLength (sizeOf (undefined :: CUInt)) (alignment (undefined :: CString))
+        pokeByteOff basePtr offsetQualifier qualifier
+
+        let offsetQualifierLength = offsetQualifier + sizeOf (undefined :: CString)
+        pokeByteOff basePtr offsetQualifierLength qualifierLength
+
+-- Helper to calculate padding between fields
+padding :: Int -> Int -> Int
+padding size align = (align - size `mod` align) `mod` align
+
+-- Helper to calculate aligned offsets
+alignedOffset :: Int -> Int -> Int -> Int
+alignedOffset base size align = base + size + padding (base + size) align
 
 withDPIXid :: Transaction -> (Ptr DPIXid -> IO a) -> IO a
 withDPIXid Transaction {..} action =

--- a/src/Database/Oracle/Simple/Transaction.hs
+++ b/src/Database/Oracle/Simple/Transaction.hs
@@ -5,7 +5,9 @@
 {-# LANGUAGE ViewPatterns #-}
 
 module Database.Oracle.Simple.Transaction
-  ( beginTransaction,
+  ( 
+    DPIXid (..),
+    beginTransaction,
     commitTransaction,
     prepareCommit,
     withTransaction,
@@ -138,7 +140,7 @@ data DPIXid = DPIXid
   , dpixBranchQualifier :: CString
   , dpixBranchQualifierLength :: CUInt
   }
-  deriving (Show)
+  deriving (Show, Eq)
 
 instance Storable DPIXid where
     sizeOf _ =


### PR DESCRIPTION
This PR addresses issue #26 by implementing manual Storable instances for DPIXid and VersionInfo, instead of relying on GStorable. 
I kindly request a review of Implementation (whether it aligned with best practices).

If the approach is deemed correct, I intend to implement manual Storable instances for other types as part of this refactoring effort. Feel free to suggest any changes, optimizations, or best practices that could enhance the implementation. Thank you for your time and guidance!

@apkhandkar @dmjio 