### PR TITLE
Suppress missed-specialisations warning for fromFloatDigits

### DIFF
--- a/src/Database/Oracle/Simple/JSON.hs
+++ b/src/Database/Oracle/Simple/JSON.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-missed-specialisations #-} -- suppressing fromFloatDigits warning
 
 module Database.Oracle.Simple.JSON (AesonField (..), JsonDecodeError (..)) where
 


### PR DESCRIPTION
While building, we get a warning as below image. 

![Screenshot from 2024-11-29 13-00-52](https://github.com/user-attachments/assets/52b354c8-ebab-4b13-8e30-24ea6a269e13)

to suppress this warning, I have added a pragma. Let me know if this is fine and merge it if you think it is. Thanks @dmjio 