### PR TITLE
The connectDPI function can now consume fields from ConnectionCreateParams.

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -297,22 +297,14 @@ spec pool = do
             result `shouldBe` dPIPoolCreateParams
         it "ConnectionCreateParams" $ \_ -> do
             someCString <- newCString "hello"
-            let dPIAppContext = DPIAppContext {
-              namespaceName = someCString
-            , namespaceNameLength = CUInt 1
-            , name = someCString
-            , nameLength = CUInt 1
-            , value = someCString
-            , valueLength = CUInt 1
-            }
             let connectionCreateParams = ConnectionCreateParams {
-              authMode = DPI_MODE_AUTH_DEFAULT
+              dpi_authMode = DPI_MODE_AUTH_DEFAULT
             , connectionClass = someCString
             , connectionClassLength = CUInt 1
             , purity = DPI_PURITY_DEFAULT
             , newPassword = someCString
             , newPasswordLength = CUInt 1
-            , appContenxt = dPIAppContext
+            , appContenxt = nullPtr
             , numAppContext = CUInt 1
             , externalAuth = CInt 1
             , externalHandle = nullPtr
@@ -325,7 +317,7 @@ spec pool = do
             , outTagFound = CInt 1
             , shardingKeyColumn = DPIShardingKeyColumn nullPtr
             , numShardingKeyColumns = 1
-            , superShardingKeyColumns = DPIShardingKeyColumn nullPtr
+            , superShardingKeyColumns = nullPtr
             , numSuperShardingKeyColumns = 1
             , outNewSession = CInt 1
             }


### PR DESCRIPTION
Previously, `connectDPI` was passing a `nullPtr` in place of `ConnectionCreateParams`, which meant there was no way to pass `ConnectionCreateParams` to `connectDPI`. This PR modifies `connectDPI` to accept values from `AdditionalConnectionParams` (the fields which are part of `ConnectionCreateParams`) and pass them to `connectDPI`.

For demonstration purposes, I have included `authMode` in `AdditionalConnectionParams`. More fields from `ConnectionCreateParams` can be added to `AdditionalConnectionParams` in the future as needed.

A design consideration arises from the fact that `AdditionalConnectionParams` contains fields for both `ConnectionCreateParams` and `PoolCreateParams`. Please let me know if this design approach is acceptable or if modifications are recommended. Thank you!

@apkhandkar @dmjio 