### PR TITLE
Close statements after use

### DIFF
--- a/src/Database/Oracle/Simple/Internal.hs
+++ b/src/Database/Oracle/Simple/Internal.hs
@@ -49,6 +49,7 @@ module Database.Oracle.Simple.Internal
     ping,
     fetch,
     close,
+    closeStatement,
     connect,
     withConnection,
     withConnCreateParams,
@@ -1908,6 +1909,18 @@ foreign import ccall unsafe "dpiConn_getIsHealthy"
     Ptr CInt ->
     IO CInt
 
+foreign import ccall "dpiStmt_close"
+  dpiStmt_close ::
+    DPIStmt ->
+    CString ->
+    CUInt ->
+    IO CInt
+
+-- | Close the statement and make it unusable for further work immediately.
+closeStatement :: DPIStmt -> IO ()
+closeStatement stmt =
+  throwOracleError =<< dpiStmt_close stmt nullPtr 0
+
 -- | A pointer to an integer defining whether the connection is healthy (1) or not (0), which will be populated upon successful completion of this function.
 isHealthy :: Connection -> IO Bool
 isHealthy (Connection fptr) =
@@ -1922,5 +1935,3 @@ Structurally equivalent to 'Data.Functor.Identity.Identity'.
 newtype Only a = Only {fromOnly :: a}
   deriving stock (Eq, Ord, Read, Show, Generic)
   deriving newtype (Enum)
-
-

--- a/src/Database/Oracle/Simple/Query.hs
+++ b/src/Database/Oracle/Simple/Query.hs
@@ -13,6 +13,7 @@ import Database.Oracle.Simple.Internal
     Connection,
     DPIModeExec (DPI_MODE_EXEC_DEFAULT),
     dpiExecute,
+    closeStatement,
     fetch,
     prepareStmt,
   )
@@ -29,7 +30,9 @@ query conn sql param = do
   found <- fetch stmt
   loop stmt found
   where
-    loop _ n | n < 1 = pure []
+    loop _ n | n < 1 = do
+      closeStatement stmt
+      pure []
     loop stmt _ = do
       tsVal <- getRow stmt
       found <- fetch stmt
@@ -43,7 +46,9 @@ query_ conn sql = do
   found <- fetch stmt
   loop stmt found
   where
-    loop _ n | n < 1 = pure []
+    loop _ n | n < 1 = do
+      closeStatement stmt
+      pure []
     loop stmt _ = do
       tsVal <- getRow stmt
       found <- fetch stmt
@@ -57,7 +62,9 @@ forEach_ conn sql cont = do
   found <- fetch stmt
   loop stmt found
   where
-    loop _ n | n < 1 = pure ()
+    loop _ n | n < 1 = do
+      closeStatement stmt
+      pure ()
     loop stmt _ = do
       tsVal <- getRow stmt
       cont tsVal


### PR DESCRIPTION
Not doing so was leading to a "maximum open cursors exceeded" error.